### PR TITLE
Feature/TAO-10019/Remove PHPUnit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,5 @@
   "minimum-stability": "dev",
   "require": {
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
-  },
-  "require-dev":{
-    "phpunit/phpunit": "6.5.0"
   }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -11,7 +11,7 @@ return array(
     'name' => 'taoAltResultStorage',
     'label' => 'Result storage key-value implementation',
     'description' => 'Implements Alternative Result storage results interface using persistencies',
-    'version' => '5.4.0',
+    'version' => '5.4.1',
     'license' => 'GPL-2.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -46,6 +46,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.2.0');
         }
 
-        $this->skip('2.2.0', '5.4.0');
+        $this->skip('2.2.0', '5.4.1');
     }
 }


### PR DESCRIPTION
Related to [https://oat-sa.atlassian.net/browse/TAO-10019](https://oat-sa.atlassian.net/browse/TAO-10019)

Remove PHPUnit dependency from the composer.json file:

- **require-dev** section was removed from the composer.json file;
- the version number was increased from 5.4.0 to 5.4.1.